### PR TITLE
Fixed a bug about deadlock at forking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,7 @@ tests/fcntl_mttest
 tests/fcntl_mptest
 tests/cond_mptest
 tests/cond_mttest
+tests/forktest
 *.k2h
 
 #

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+fullock (1.0.23) trusty; urgency=low
+
+  * Fixed a bug about deadlock at forking
+
+ -- Takeshi Nakatani <ggtakec@gmail.com>  Mon, 13 Feb 2017 17:08:41 +0900
+
+fullock (1.0.22) trusty; urgency=low
+
+  * Changed exclusive control more strictly
+
+ -- Takeshi Nakatani <ggtakec@gmail.com>  Mon, 06 Feb 2017 13:47:09 +0900
+
 fullock (1.0.21) trusty; urgency=low
 
   * First version of open source on Github

--- a/lib/flckshm.cc
+++ b/lib/flckshm.cc
@@ -476,6 +476,21 @@ bool FlShm::CheckCondDeadLock(fl_pid_cache_map_t* pcache_map, flckpid_t flckpid,
 }
 
 //---------------------------------------------------------
+// FlShm : For Forking
+//---------------------------------------------------------
+// When the program which loads this fullock library is forked, we need to start worker thread
+// in child process.
+//
+void FlShm::PreforkHandler(void)
+{
+	if(FlShm::pCheckPidThread){
+		if(!FlShm::pCheckPidThread->ReInitializeThread()){
+			ERR_FLCKPRN("Call Prefork handler and try to run thread for child process(%d), but FAILED TO RUN THREAD", getpid());
+		}
+	}
+}
+
+//---------------------------------------------------------
 // FlShm : Lock
 //---------------------------------------------------------
 bool FlShm::CheckAttach(void)

--- a/lib/flckshm.h
+++ b/lib/flckshm.h
@@ -106,6 +106,7 @@ class FlShm
 		static FlShm* get(void) { return &FlShm::singleton; }
 		static bool LoadEnv(void);
 
+		static void PreforkHandler(void);						// for forking
 		static bool CheckAttach(void);
 		static bool Attach(void);
 		static bool Detach(void);

--- a/lib/flckshminit.cc
+++ b/lib/flckshminit.cc
@@ -214,6 +214,16 @@ bool FlShm::InitializeShm(void)
 			FlShm::Detach();
 			return false;
 		}
+
+		// [NOTE]
+		// When the program which loads this fullock library is forked, we need to start worker thread
+		// in child process.
+		// Thus we set a handler at forking, and it initializes and runs thread in child process.
+		//
+		int	result;
+		if(0 != (result = pthread_atfork(NULL, NULL, PreforkHandler))){
+			ERR_FLCKPRN("Failed to set handler for forking(errno=%d), but continue...", result);
+		}
 	}
 	return true;
 }

--- a/lib/flckthread.h
+++ b/lib/flckthread.h
@@ -41,18 +41,26 @@ class FlckThread
 			FLCK_THCNTL_RUN	= 0,
 			FLCK_THCNTL_STOP,
 			FLCK_THCNTL_EXIT,
+			FLCK_THCNTL_FIN
 		}THCNTLFLAG;
 
 		static const int	DEFAULT_INTERVALMS	= 10;		// default interval ms
 
 	protected:
 		static const int	FLCK_WAIT_EVENT_MAX	= 32;		// wait event max count
+		static int			InotifyFd;
+		static int			WatchFd;
+		static int			EventFd;
+		static void*		pThreadParam;					// free point using in worker thread
 
 		volatile THCNTLFLAG	thflag;							// thread control flags
+		int					bup_intervalms;					// backup for forking
+		std::string			bup_filepath;					// backup for forking
 		bool				is_run_worker;
 		pthread_t			pthreadid;						// worker thread id
 
 	protected:
+		static void CleanupHandler(void* arg);				// cleanup handler by canceling thread
 		static void* WorkerProc(void* param);
 		static bool CheckEvent(int InotifyFd, int WatchFd);
 
@@ -62,7 +70,8 @@ class FlckThread
 		FlckThread();
 		virtual ~FlckThread();
 
-		bool InitializeThread(const char* pfile, int intervalms = FlckThread::DEFAULT_INTERVALMS, bool is_stop = true);
+		bool InitializeThread(const char* pfile, int intervalms = FlckThread::DEFAULT_INTERVALMS);
+		bool ReInitializeThread(void);
 		bool Run(void);
 		bool Stop(void);
 		bool Exit(void);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -14,7 +14,7 @@
 # REVISION:
 #
 
-noinst_PROGRAMS = fullocktest singletest mttest mptest cond_mttest cond_mptest fcntl_mttest fcntl_mptest
+noinst_PROGRAMS = fullocktest singletest mttest mptest cond_mttest cond_mptest fcntl_mttest fcntl_mptest forktest
 
 fullocktest_SOURCES = fullocktest.cc
 fullocktest_LDADD = -L../lib/.libs -lfullock -lpthread
@@ -39,6 +39,9 @@ fcntl_mttest_LDADD = -L../lib/.libs -lfullock -lpthread
 
 fcntl_mptest_SOURCES = fcntl_mptest.cc
 fcntl_mptest_LDADD = -L../lib/.libs -lfullock
+
+forktest_SOURCES = forktest.cc
+forktest_LDADD = 
 
 ACLOCAL_AMFLAGS = -I m4
 AM_CFLAGS = -I$(top_srcdir)/lib

--- a/tests/forktest.cc
+++ b/tests/forktest.cc
@@ -1,0 +1,166 @@
+/*
+ * FULLOCK - Fast User Level LOCK library by Yahoo! JAPAN
+ *
+ * Copyright 2015 Yahoo! JAPAN corporation.
+ *
+ * FULLOCK is fast locking library on user level by Yahoo! JAPAN.
+ * FULLOCK is following specifications.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * AUTHOR:   Takeshi Nakatani
+ * CREATE:   Mon 13 Feb 2016
+ * REVISION:
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <dlfcn.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <stdarg.h>
+#include <libgen.h>
+#include <string.h>
+#include "flckutil.h"
+
+#include <string>
+
+using namespace	std;
+
+//---------------------------------------------------------
+// Macros and Symbols
+//---------------------------------------------------------
+#define	DEFAULT_CHILDPROC_CNT	10
+
+//---------------------------------------------------------
+// Utility Functions
+//---------------------------------------------------------
+static inline void PRN(const char* format, ...)
+{
+	if(format){
+		va_list ap;
+		va_start(ap, format);
+		vfprintf(stdout, format, ap); 
+		va_end(ap);
+	}
+	fprintf(stdout, "\n");
+}
+
+static inline void ERR(const char* format, ...)
+{
+	fprintf(stderr, "[ERR] ");
+	if(format){
+		va_list ap;
+		va_start(ap, format);
+		vfprintf(stderr, format, ap); 
+		va_end(ap);
+	}
+	fprintf(stderr, "\n");
+}
+
+static inline std::string programname(const char* prgpath)
+{
+	string	strresult("program");
+	if(!prgpath){
+		return strresult;
+	}
+	char*	tmpname  = strdup(prgpath);
+	char*	pprgname = basename(tmpname);
+	if(0 == strncmp(pprgname, "lt-", strlen("lt-"))){
+		pprgname = &pprgname[strlen("lt-")];
+	}
+	strresult = pprgname;
+	FLCK_Free(tmpname);
+	return strresult;
+}
+
+static void Help(const char* progname)
+{
+	PRN(NULL);
+	PRN("Usage: %s [<libfullock path> [run child process count(default 10)]]", programname(progname).c_str());
+	PRN(NULL);
+}
+
+//---------------------------------------------------------
+// Main
+//---------------------------------------------------------
+int main(int argc, const char** argv)
+{
+	int		childcnt	= DEFAULT_CHILDPROC_CNT;
+	string	fullockpath	= "libfullock.so";
+	if(3 < argc){
+		ERR("Unkown parameter is %s", argv[3]);
+		Help(argv[0]);
+		exit(EXIT_FAILURE);
+	}else if(1 < argc){
+		fullockpath = argv[1];
+		if(2 < argc){
+			if(0 >= (childcnt = atoi(argv[2]))){
+				ERR("Parameter %s is wrong", argv[2]);
+				Help(argv[0]);
+				exit(EXIT_FAILURE);
+			}
+		}
+	}
+
+	// load library
+	void*	dhandle = dlopen(fullockpath.c_str(), RTLD_LAZY);
+	if(!dhandle){
+		ERR("Could not load libfullock.so(path: %s)", fullockpath.c_str());
+		exit(EXIT_FAILURE);
+	}
+	sleep(1);
+
+	// fork
+	pid_t	childpid;
+	bool	parent = true;
+	for(int cnt = 0; childcnt > cnt; ++cnt){
+		childpid = fork();
+		if(-1 == childpid){
+			ERR("Could not fork no.%d child process", cnt);
+			exit(EXIT_FAILURE);
+		}else if(0 == childpid){
+			//PRN("Succeed to wakeup no.%d child process(pid=%d)", cnt, getpid());
+			parent = false;
+			sleep(2);
+			break;
+		}else{
+			//PRN("Succeed to run no.%d child process(pid=%d)", cnt, getpid());
+		}
+	}
+
+	// unload library(parent/child process)
+	dlclose(dhandle);
+
+	// wait exiting children in parent process
+	if(parent){
+		sleep(5);		// 5s = enough for exiting children.
+		int	cnt;
+		int	limitcnt;
+		for(cnt = childcnt, limitcnt = 10; 0 < cnt && 0 < limitcnt; ){
+			int	status;
+			if(0 < waitpid(-1, &status, WNOHANG)){
+				--cnt;
+				//PRN("Succeed to exit child process, rest child process count = %d", cnt);
+			}else{
+				// no children is exiting, wait 1s(total 10s).
+				--limitcnt;
+				sleep(1);
+			}
+		}
+		if(0 != cnt && 0 == limitcnt){
+			ERR("Some children could not exit.");
+			exit(EXIT_FAILURE);
+		}
+	}
+	exit(EXIT_SUCCESS);
+}
+
+/*
+ * VIM modelines
+ *
+ * vim:set ts=4 fenc=utf-8:
+ */

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -23,7 +23,7 @@ if [ "X${SRCTOP}" = "X" ]; then
 	SRCTOP=`cd ${MYSCRIPTDIR}/..; pwd`
 fi
 if [ "X${OBJDIR}" = "X" ]; then
-	LD_LIBRARY_PATH="${SRCTOP}/lib/.lib"
+	LD_LIBRARY_PATH="${SRCTOP}/lib/.libs"
 	TESTPROGDIR=${MYSCRIPTDIR}
 else
 	LD_LIBRARY_PATH="${SRCTOP}/lib/${OBJDIR}"
@@ -588,6 +588,26 @@ REST_PROCESSES=`ps ax | grep fullocktest | grep -v grep | awk '{print $1}'`
 kill -HUP $REST_PROCESSES 2> /dev/null
 sleep 1
 kill -9 $REST_PROCESSES 2> /dev/null
+
+##############################################################
+### Test forking
+###
+echo "-- Test forking -------------------------" >> $LOGFILE
+echo "" >> $LOGFILE
+${TESTPROGDIR}/forktest >> $LOGFILE
+
+if [ $? -ne 0 ]; then
+	echo "Test forking --->> ERROR"
+	echo "Test forking --->> ERROR" >> $LOGFILE
+	echo ""
+	echo "---------------- Test forking log ----------------"
+	cat $LOGFILE
+	put_result_xml_func NG ${XMLRESULTSFILE}
+	exit 1
+fi
+echo "Test forking --->> OK"
+echo "Test forking --->> OK" >> $LOGFILE
+echo "" >> $LOGFILE
 
 ##############################################################
 ### Remove file


### PR DESCRIPTION
#### Relevant Issue (if applicable)
n/a

#### Details
1. Exclusive control in the processing of fl_unlock_rwlock () and fl_list_base () was more strict.(1.0.22)

2. fullock creates one thread for itself at loaded it(dlopen).  
This caused the program to deadlock if the program loaded with fullock forked.  
This bug was fixed by the following method.
 - When fullock is unloaded(including at the end of the program), use pthread_cancel() to terminate the thread.
 - Use a cleanup handler at exiting thread(use pthread_cleanup_push/pop)
 - Use non portable pthread_tryjoin_np function instead of pthread_join
 - Use a handler at forking(use pthread_atfork)
 - Add a program for test of forking

3. increment version number