### PR TITLE
Updated files for release 1.0.30

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+fullock (1.0.30) trusty; urgency=low
+
+  * Fixed lintian error in man page about wrong word(2)
+
+ -- Takeshi Nakatani <ggtakec@gmail.com>  Wed, 17 Oct 2018 14:57:02 +0900
+
+fullock (1.0.29) trusty; urgency=low
+
+  * Fixed lintian error in man page about wrong word
+
+ -- Takeshi Nakatani <ggtakec@gmail.com>  Wed, 17 Oct 2018 13:46:05 +0900
+
 fullock (1.0.28) trusty; urgency=low
 
   * avoid static object initialization order problem(SIOF) - #4

--- a/docs/fullock.3
+++ b/docs/fullock.3
@@ -124,7 +124,7 @@ MIT License
 Copyright (C) 2015 Yahoo Japan Corporation
 .PP
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the \*(L"Software\*(R"), to deal
+of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
@@ -133,10 +133,10 @@ furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 .PP
-\&\s-1THE SOFTWARE IS PROVIDED \*(L"AS IS\*(R", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
 OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
 THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.\s0
+DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Changes from 1.0.29 to 1.0.30

#### 1.0.29
- Fixed lintian error in man page about wrong word  
Fixed issue that there was an invalid character in the man page and an error occurred in Lintian.

#### 1.0.30
- Fixed lintian error in man page about wrong word(2)
Refixed issue that there was an invalid character in the man page and an error occurred in Lintian.


