### PR TITLE
Fixes typos.

### DIFF
--- a/lib/flckthread.cc
+++ b/lib/flckthread.cc
@@ -251,7 +251,7 @@ void* FlckThread::WorkerProc(void* param)
 
 			}else if(-1 >= eventcnt){
 				if(EINTR != errno){
-					ERR_FLCKPRN("Something error occured in waiting event(errno=%d): inotifyfd(%d) watchfd(%d) event fd(%d)", errno, FlckThread::InotifyFd, FlckThread::WatchFd, FlckThread::EventFd);
+					ERR_FLCKPRN("Something error occurred in waiting event(errno=%d): inotifyfd(%d) watchfd(%d) event fd(%d)", errno, FlckThread::InotifyFd, FlckThread::WatchFd, FlckThread::EventFd);
 					break;
 				}
 				// signal occurred.

--- a/lib/flckutil.cc
+++ b/lib/flckutil.cc
@@ -391,11 +391,11 @@ static bool RawFileLock(int fd, short type, off_t offset, bool block)
 		}else{
 			if(!block){
 				if(EACCES != errno && EAGAIN != errno){
-					//MSG_FLCKPRN("Could not \"%s\" lock because something unnormal wrong occured. errno=%d", LOCKTYPE_STR(type), errno);
+					//MSG_FLCKPRN("Could not \"%s\" lock because something unnormal wrong occurred. errno=%d", LOCKTYPE_STR(type), errno);
 				}
 				break;
 			}else{
-				//MSG_FLCKPRN("Could not \"%s\" lock because something unnormal wrong occured. errno=%d", LOCKTYPE_STR(type), errno);
+				//MSG_FLCKPRN("Could not \"%s\" lock because something unnormal wrong occurred. errno=%d", LOCKTYPE_STR(type), errno);
 				break;
 			}
 		}


### PR DESCRIPTION
#### Relevant Issue (if applicable)
Typos reported by debian lintian. The severity is "wishlist".

#### Details
Here is an output that I tried debianizd fullock.

```
$ debuild
...
I: libfullock1: spelling-error-in-binary usr/lib/x86_64-linux-gnu/libfullock.so.1.0.36 occured occurred
N: 
N:    Lintian found a spelling error in the given binary. Lintian has a list
N:    of common misspellings that it looks for. It does not have a dictionary
N:    like a spelling checker does.
N:    
N:    If the string containing the spelling error is translated with the help
N:    of gettext or a similar tool, please fix the error in the translations
N:    as well as the English text to avoid making the translations fuzzy. With
N:    gettext, for example, this means you should also fix the spelling
N:    mistake in the corresponding msgids in the *.po files.
N:    
N:    You can often find the word in the source code by running:
N:    
N:     grep -rw <word> <source-tree>
N:    
N:    This tag may produce false positives for words that contain non-ASCII
N:    characters due to limitations in strings.
N:    
N:    Severity: minor, Certainty: wild-guess
N:    
N:    Check: binaries, Type: binary, udeb
N: 
Finished running lintian.
```
