### PR TITLE
Drops Fedora28 and CentOS6.x from our support OS

### DIFF
--- a/build.md
+++ b/build.md
@@ -19,13 +19,19 @@ This chapter instructs how to build **FULLOCK** and install it and its header fi
 
 ## 1. Install prerequisites
 
-For DebianStretch or Ubuntu(Bionic Beaver) users, follow the steps below.
+For recent Debian-based Linux distributions users, follow the steps below:
 ```
 $ sudo apt-get update -y
 $ sudo apt install git autoconf automake libtool g++ -y
 ```
 
-For Fedora28 or CentOS7.x(6.x) users, follow the steps below.
+For users who use supported Fedora other than latest version, follow the steps below:
+```
+$ sudo dnf makecache
+$ sudo dnf install git gcc-c++ make libtool -y
+```
+
+For other recent RPM-based Linux distributions users, follow the steps below:
 ```
 $ sudo yum makecache
 $ sudo yum install git gcc-c++ make libtool -y

--- a/buildja.md
+++ b/buildja.md
@@ -19,13 +19,19 @@ next_string: Developer
 
 ## 1.ビルド環境の構築
 
-DebianStretchまたはUbuntu（Bionic Beaver）をお使いの場合は、以下の手順に従ってください。
+最近のDebianベースLinuxの利用者は、以下の手順に従ってください。
 ```
 $ sudo apt-get update -y
 $ sudo apt install git autoconf automake libtool g++ -y
 ```
 
-Fedora28またはCentOS7.x（6.x）ユーザーの場合は、以下の手順に従ってください。
+Fedoraの利用者は、以下の手順に従ってください。
+```
+$ sudo dnf makecache
+$ sudo dnf install git gcc-c++ make libtool -y
+```
+
+その他最近のRPMベースのLinuxの場合は、以下の手順に従ってください。
 ```
 $ sudo yum makecache
 $ sudo yum install git gcc-c++ make libtool -y

--- a/feature.md
+++ b/feature.md
@@ -15,6 +15,9 @@ next_string: Usage
 
 # Feature
 
+## Flexible installation
+We provide suitable FULLOCK installation for your OS. If you use Ubuntu, CentOS, Fedora or Debian, you can easily install it from [packagecloud.io] (https://packagecloud.io/antpickax/stable). Even if you use none of them, you can use it by [Build] (https://fullock.antpick.ax/build.html) by yourself.
+
 ## Provided functions
 FULLOCK provides the following locking mechanism.
 

--- a/featureja.md
+++ b/featureja.md
@@ -15,6 +15,9 @@ next_string: Usage
 
 # FULLOCKの特徴
 
+## 柔軟なインストール
+FULLOCKは、あなたのOSに応じて、柔軟にインストールが可能です。あなたのOSが、Ubuntu、CentOS、Fedora、Debianなら、[packagecloud.io](https://packagecloud.io/antpickax/stable)からソースコードをビルドすることなく、簡単にインストールできます。それ以外のOSであっても、自身で[ビルド](https://fullock.antpick.ax/buildja.html)して使うことができます。
+
 ## 提供機能
 FULLOCKは以下の機能を提供します。
 

--- a/usage.md
+++ b/usage.md
@@ -26,7 +26,7 @@ The FULLOCK library publishes [packages](https://packagecloud.io/app/antpickax/s
 The package of the FULLOCK library is released in the form of Debian package, RPM package.  
 Since the installation method differs depending on your OS, please check the following procedure and install it.  
 
-#### Debian(Stretch) / Ubuntu(Bionic Beaver)
+#### For recent Debian-based Linux distributions users, follow the steps below:
 ```
 $ sudo apt-get update -y
 $ sudo apt-get install curl -y
@@ -38,7 +38,19 @@ To install the developer package, please install the following package.
 $ sudo apt-get install libfullock-dev
 ```
 
-#### Fedora28 / CentOS7.x(6.x)
+#### For users who use supported Fedora other than latest version, follow the steps below:
+```
+$ sudo dnf makecache
+$ sudo dnf install curl -y
+$ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.rpm.sh | sudo bash
+$ sudo dnf install libfullock
+```
+To install the developer package, please install the following package.
+```
+$ sudo dnf install libfullock-devel
+```
+
+#### For other recent RPM-based Linux distributions users, follow the steps below:
 ```
 $ sudo yum makecache
 $ sudo yum install curl -y

--- a/usageja.md
+++ b/usageja.md
@@ -26,7 +26,7 @@ FULLOCKライブラリは、誰でも利用できるように[packagecloud.io - 
 FULLOCKライブラリのパッケージは、Debianパッケージ、RPMパッケージの形式で公開しています。  
 お使いのOSによりインストール方法が異なりますので、以下の手順を確認してインストールしてください。  
 
-#### Debian(Stretch) / Ubuntu(Bionic Beaver)
+#### 最近のDebianベースLinuxの利用者は、以下の手順に従ってください。
 ```
 $ sudo apt-get update -y
 $ sudo apt-get install curl -y
@@ -38,7 +38,19 @@ $ sudo apt-get install libfullock
 $ sudo apt-get install libfullock-dev
 ```
 
-#### Fedora28 / CentOS7.x(6.x)
+#### Fedoraの利用者は、以下の手順に従ってください。
+```
+$ sudo dnf makecache
+$ sudo dnf install curl -y
+$ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.rpm.sh | sudo bash
+$ sudo dnf install libfullock
+```
+開発者向けパッケージをインストールする場合は、以下のパッケージをインストールしてください。
+```
+$ sudo dnf install libfullock-devel
+```
+
+#### その他最近のRPMベースのLinuxの場合は、以下の手順に従ってください。
 ```
 $ sudo yum makecache
 $ sudo yum install curl -y


### PR DESCRIPTION
## Relevant Issue (if applicable)
N/A

## Details
This PR removes unsupported OS descrptions from the manuals.