### PR TITLE
Fixed ci.yml for Docker image build/push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      #
+      # Login to avoid the Docker Hub rate limit
+      #
+      # Github Secret cannot be read in the case of Pull Request, so that process
+      # here will fail, so we need to skip it. Even if we skip this process, if we
+      # are using the official Runner of Github Actions, the IP address rate will
+      # not be limited and we will not get an error.
+      # However, this restriction release is based on the contract between Github
+      # and DockerHub, so if we skip this process, we may get an error.
+      #
       - name: Login to DockerHub
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}


### PR DESCRIPTION
### Relevant Issue (if applicable)
#43 

### Details
Changed to not login to DockerHub only for pull requests when building and pushing Docker images on Github Actions.
For PullRequest, this is because you can't read the Github secret.
We also confirmed that there are no IP address rate limit on access to DockerHub from the official Github Actions Runner.
Currently, the login process is not limited to pull requests, although it may change in the future.

