### PR TITLE
Fixed to create /var/lib/antpickax at installation

### DIFF
--- a/buildutils/libfullock.postinst
+++ b/buildutils/libfullock.postinst
@@ -1,9 +1,10 @@
+#!/bin/sh
 #
 # FULLOCK - Fast User Level LOCK library
 #
 # Utility tools for building configure/packages by AntPickax
 #
-# Copyright 2018 Yahoo Japan Corporation.
+# Copyright 2021 Yahoo Japan Corporation.
 #
 # AntPickax provides utility tools for supporting autotools
 # builds.
@@ -19,22 +20,21 @@
 # the license file that was distributed with this source code.
 #
 # AUTHOR:   Takeshi Nakatani
-# CREATE:   Fri, Apr 13 2018
+# CREATE:   Fri, Aug 13 2021
 # REVISION:
 #
 
-EXTRA_DIST =make_variables.sh \
-			make_release_version_file.sh \
-			make_commit_hash.sh \
-			make_commit_hash_source.sh \
-			make_rpm_changelog.sh \
-			make_description.sh \
-			debian_build.sh \
-			rpm_build.sh \
-			libfullock.postinst
+#
+# Create /var/lib/antpickax directory
+#
+mkdir -p /var/lib/antpickax
+chmod 0777 /var/lib/antpickax
 
 #
-# VIM modelines
-#
-# vim:set ts=4 fenc=utf-8:
+# Local variables:
+# tab-width: 4
+# c-basic-offset: 4
+# End:
+# vim600: expandtab sw=4 ts=4 fdm=marker
+# vim<600: expandtab sw=4 ts=4
 #

--- a/buildutils/libfullock.spec.in
+++ b/buildutils/libfullock.spec.in
@@ -62,6 +62,7 @@ BuildRequires: git-core gcc-c++ make libtool
 %install
 %make_install
 find %{buildroot} -name '*.la' -exec rm -f {} ';'
+mkdir -p %{buildroot}/var/lib/antpickax
 
 %if %{make_check}
 %check
@@ -90,6 +91,7 @@ rm -rf %{buildroot}
 %doc README AUTHORS ChangeLog
 %{_libdir}/libfullock.so.1*
 %{_mandir}/man3/*
+%dir %attr(0777,root,root) /var/lib/antpickax
 
 #
 # devel package


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Changed the judgment process of the default SHM directory.
Changed to use `/tmp` instead of creating the `/var/lib/antpickax` directory if it doesn't exist.
And also added the `/var/lib/antpickax` directory to the package.
