### PR TITLE
Fixed Dockerfile template for calling ldconfig

### DIFF
--- a/.github/workflows/docker_helper.sh
+++ b/.github/workflows/docker_helper.sh
@@ -384,6 +384,7 @@ echo "  PKG_INSTALL_LIST_BIN     = ${PKG_INSTALL_LIST_BIN}"
 echo "  BUILDER_CONFIGURE_FLAG   = ${BUILDER_CONFIGURE_FLAG}"
 echo "  BUILDER_MAKE_FLAGS       = ${BUILDER_MAKE_FLAGS}"
 echo "  BUILDER_ENVIRONMENT      = ${BUILDER_ENVIRONMENT}"
+echo "  UPDATE_LIBPATH           = ${UPDATE_LIBPATH}"
 echo "  RUNNER_INSTALL_PACKAGES  = ${RUNNER_INSTALL_PACKAGES}"
 
 #---------------------------------------------------------------------
@@ -456,18 +457,25 @@ if [ "X${PKG_INSTALL_LIST_BUILDER}" != "X" ]; then
 	PKG_INSTALL_BUILDER_COMMAND="${PKGMGR_NAME} ${PKGMGR_INSTALL_OPT} ${PKG_INSTALL_LIST_BUILDER}"
 else
 	#
-	# Set dummy command
+	# Set no-operation command
 	#
-	PKG_INSTALL_BUILDER_COMMAND="sleep 0"
+	PKG_INSTALL_BUILDER_COMMAND=":"
 fi
 
 if [ "X${PKG_INSTALL_LIST_BIN}" != "X" ]; then
 	PKG_INSTALL_BIN_COMMAND="${PKGMGR_NAME} ${PKGMGR_INSTALL_OPT} ${PKG_INSTALL_LIST_BIN}"
 else
 	#
-	# Set dummy command
+	# Set no-operation command
 	#
-	PKG_INSTALL_BIN_COMMAND="sleep 0"
+	PKG_INSTALL_BIN_COMMAND=":"
+fi
+
+if [ "X${UPDATE_LIBPATH}" = "X" ]; then
+	#
+	# Set no-operation command
+	#
+	UPDATE_LIBPATH=":"
 fi
 
 cat ${BUILDUTILS_DIR}/${DOCKER_TEMPL_FILE} |							\
@@ -481,6 +489,7 @@ cat ${BUILDUTILS_DIR}/${DOCKER_TEMPL_FILE} |							\
 		-e "s#%%PKG_INSTALL_BIN%%#${PKG_INSTALL_BIN_COMMAND}#g"			\
 		-e "s#%%CONFIGURE_FLAG%%#${BUILDER_CONFIGURE_FLAG}#g"			\
 		-e "s#%%BUILD_FLAGS%%#${BUILDER_MAKE_FLAGS}#g"					\
+		-e "s#%%UPDATE_LIBPATH%%#${UPDATE_LIBPATH}#g"					\
 		-e "s#%%BUILD_ENV%%#${BUILDER_ENVIRONMENT}#g"					> ${SRCTOP}/${DOCKER_FILE}
 if [ $? -ne 0 ]; then
 	echo "[ERROR] ${PRGNAME} : Failed to creating ${DOCKER_FILE} from ${DOCKER_TEMPL_FILE}."

--- a/.github/workflows/imagetypevars.sh
+++ b/.github/workflows/imagetypevars.sh
@@ -48,6 +48,7 @@ PKG_INSTALL_LIST_BIN=
 BUILDER_CONFIGURE_FLAG=
 BUILDER_MAKE_FLAGS=
 BUILDER_ENVIRONMENT=
+UPDATE_LIBPATH=
 
 #
 # List the package names that contain pacakgecloud.io to install on Github Actions Runner.
@@ -70,6 +71,7 @@ elif [ "X${DOCKER_IMAGE_OSTYPE}" = "Xubuntu" ]; then
 	PKGMGR_INSTALL_OPT="install -qq -y"
 	PKG_INSTALL_LIST_BUILDER="git autoconf autotools-dev gcc g++ make gdb dh-make fakeroot dpkg-dev devscripts libtool pkg-config procps"
 	PKG_INSTALL_LIST_BIN=""
+	UPDATE_LIBPATH="ldconfig"
 
 	#
 	# For installing tzdata with another package(ex. git)

--- a/buildutils/Dockerfile.templ.in
+++ b/buildutils/Dockerfile.templ.in
@@ -31,7 +31,8 @@
 #	PKG_INSTALL_BIN				(ex. "apk add -q --no-progress --no-cache libstdc++")
 #	CONFIGURE_FLAG				(ex. "")
 #	BUILD_FLAGS					(ex. "CXXFLAGS=")
-#	BUILD_ENV					(ex, "ENV DEBIAN_FRONTEND=noninteractive")
+#	BUILD_ENV					(ex. "ENV DEBIAN_FRONTEND=noninteractive")
+#	UPDATE_LIBPATH				(ex. "ldconfig", if want no-operation, specify ":")
 #
 
 #
@@ -80,7 +81,8 @@ COPY --from=@PACKAGE_NAME@-builder /lib@PACKAGE_NAME@-dev.tgz                   
 
 RUN cd / && \
 	tar xvzf lib@PACKAGE_NAME@-dev.tgz && \
-	rm /lib@PACKAGE_NAME@-dev.tgz
+	rm /lib@PACKAGE_NAME@-dev.tgz && \
+	%%UPDATE_LIBPATH%%
 
 CMD ["/bin/sh"]
 
@@ -103,7 +105,8 @@ COPY --from=@PACKAGE_NAME@-builder /lib@PACKAGE_NAME@.tgz /lib@PACKAGE_NAME@.tgz
 
 RUN cd / && \
 	tar xvzf lib@PACKAGE_NAME@.tgz && \
-	rm /lib@PACKAGE_NAME@.tgz
+	rm /lib@PACKAGE_NAME@.tgz && \
+	%%UPDATE_LIBPATH%%
 
 CMD ["/bin/sh"]
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Changed to call `ldconfig` when creating Docker image for ubuntu.
This is the call needed to find files under `/usr/local/lib` on ubuntu.
Along with this, the related files have been updated.