### PR TITLE
Enabled external customization of variables in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,7 +54,7 @@ AC_CHECK_LIB(dl, dlopen)
 #
 # Checks for header files.
 #
-AC_CHECK_HEADERS([stdlib.h stdio.h string.h fcntl.h limits.h])
+AC_CHECK_HEADERS([stdlib.h stdio.h string.h fcntl.h limits.h inttypes.h stdint.h strings.h unistd.h])
 
 #
 # Checks for typedefs, structures, and compiler characteristics.
@@ -66,6 +66,7 @@ AC_TYPE_PID_T
 AC_TYPE_SIZE_T
 AC_TYPE_SSIZE_T
 AC_TYPE_UINT64_T
+AC_TYPE_UINT32_T
 AC_TYPE_MODE_T
 
 #
@@ -80,15 +81,37 @@ AC_CHECK_FUNCS([memset strcasecmp clock_gettime ftruncate mkdir munmap setenv st
 AC_CONFIG_MACRO_DIR([m4])
 
 #
+# Load customizable variables
+#
+AC_CHECK_FILE([configure.custom],
+	[
+		custom_git_domain="$(grep '^\s*GIT_DOMAIN\s*=' configure.custom | sed -e 's|^\s*GIT_DOMAIN\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_git_org="$(grep '^\s*GIT_ORG\s*=' configure.custom | sed -e 's|^\s*GIT_ORG\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_git_repo="$(grep '^\s*GIT_REPO\s*=' configure.custom | sed -e 's|^\s*GIT_REPO\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_git_endpoint="$(grep '^\s*GIT_EP_V3_REPO\s*=' configure.custom | sed -e 's|^\s*GIT_EP_V3_REPO\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_dev_email="$(grep '^\s*DEV_EMAIL\s*=' configure.custom | sed -e 's|^\s*DEV_EMAIL\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_dev_name="$(grep '^\s*DEB_NAME\s*=' configure.custom | sed -e 's|^\s*DEB_NAME\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+	],
+	[
+		custom_git_domain="github.com"
+		custom_git_org="yahoojapan"
+		custom_git_repo="fullock"
+		custom_git_endpoint="https://api.github.com/repos/"
+		custom_dev_email="antpickax@mail.yahoo.co.jp"
+		custom_dev_name="FULLOCK_DEVELOPER"
+	]
+)
+
+#
 # Symbols for buildutils
 #
-AC_SUBST([GIT_DOMAIN], "github.com")
-AC_SUBST([GIT_ORG], "yahoojapan")
-AC_SUBST([GIT_REPO], "fullock")
-AC_SUBST([CURRENTREV], "`$(pwd)/buildutils/make_commit_hash.sh -o yahoojapan -r fullock -short`")
-AC_SUBST([DEV_EMAIL], "`echo ${DEBEMAIL:-antpickax-support@mail.yahoo.co.jp}`")
-AC_SUBST([DEV_NAME], "`echo ${DEBFULLNAME:-FULLOCK_DEVELOPER}`")
-
+AC_SUBST([GIT_DOMAIN], "${custom_git_domain}")
+AC_SUBST([GIT_ORG], "${custom_git_org}")
+AC_SUBST([GIT_REPO], "${custom_git_repo}")
+AC_SUBST([CURRENTREV], "$($(pwd)/buildutils/make_commit_hash.sh -o yjcore -r fullock -ep "${custom_git_endpoint}" -short)")
+AC_SUBST([DEV_EMAIL], "$(echo ${DEBEMAIL:-"${custom_dev_email}"})")
+AC_SUBST([DEV_NAME], "$(echo ${DEBFULLNAME:-"${custom_dev_name}"})")
+#
 AC_SUBST([RPMCHANGELOG], "`$(pwd)/buildutils/make_rpm_changelog.sh $(pwd)/ChangeLog`")
 AC_SUBST([SHORTDESC], "`$(pwd)/buildutils/make_description.sh $(pwd)/docs/fullock.3 -short`")
 AC_SUBST([LONGDESC], "`$(pwd)/buildutils/make_description.sh $(pwd)/docs/fullock.3 -long`")


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Enabled to customize variables in `configure.ac`.
If the `configure.custom` file exists, it will be loaded.
(currently unused but added to increase availability)

