### PR TITLE
Added gcc -fno-lto option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -143,8 +143,18 @@ AM_SUBST_NOTMAKE([CONFIGUREWITHOPT])
 #
 # CFLAGS/CXXFLAGS
 #
-CFLAGS="-Wall $CFLAGS"
-CXXFLAGS="-Wall $CXXFLAGS"
+# [NOTE]
+# CFLAGS is given "-flto=auto" depending on some OS(Rocky Linux 9, Fedora 36,
+# Ubuntu 22.04) and GCC version(GCC 11), packaging tools(rpmbuild).
+# We have confirmed a case where Segmentation Fault occurs when calling from
+# PHP on Fedora 36 and Rocky Linux 9 when using a library with Link Time
+# Optimization(-flto) enabled.
+# Thus, we have determined that this option does not have a significant
+# advantage in fullock, so we will add the "-fno_lto" option to avoid using
+# it.
+#
+CFLAGS="-Wall $CFLAGS -fno-lto"
+CXXFLAGS="-Wall $CXXFLAGS -fno-lto"
 
 #
 # Checking Libraries


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
In combination with some OS and runtime, a segmentation fault sometimes occurred when unloading this library.
This depends on the LTO optimization, so I added the `-fno-lto` option.