### PR TITLE
Updated changelog for v1.0.57

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+fullock (1.0.57) unstable; urgency=low
+
+  * Fixed build_helper.sh for ruby 2.7 required package_cloud - #108
+
+ -- Takeshi Nakatani <ggtakec@gmail.com>  Thu, 16 Nov 2023 14:50:49 +0900
+
 fullock (1.0.56) unstable; urgency=low
 
   * Fixed a bug in build_helper.sh - #105


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
#### Changes from 1.0.56 to 1.0.57
- Fixed build_helper.sh for ruby 2.7 required package_cloud - #108