### PR TITLE
Added a directory to be created by the package

### DIFF
--- a/buildutils/APKBUILD.templ.in
+++ b/buildutils/APKBUILD.templ.in
@@ -106,9 +106,11 @@ package() {
 	make DESTDIR="$pkgdir" install
 
 	#
-	# Create /var/lib/antpickax directory
+	# Create /var/run/antpickax, /var/lib/antpickax, /etc/antpickax directory
 	#
+	install -v -m 0777 -d "$pkgdir"/var/run/antpickax
 	install -v -m 0777 -d "$pkgdir"/var/lib/antpickax
+	install -v -m 0777 -d "$pkgdir"/etc/antpickax
 }
 
 # [NOTE]

--- a/buildutils/Dockerfile.templ.in
+++ b/buildutils/Dockerfile.templ.in
@@ -55,6 +55,10 @@ RUN set -x && \
 	%%UPDATE_LIBPATH%% && \
 	mkdir -p /var/lib/antpickax && \
 	chmod 0777 /var/lib/antpickax && \
+	mkdir -p /var/run/antpickax && \
+	chmod 0777 /var/run/antpickax && \
+	mkdir -p /etc/antpickax && \
+	chmod 0777 /etc/antpickax && \
 	%%PKG_UNINSTALL_DEV%% && \
 	%%POST_PROCESS%%
 
@@ -79,6 +83,10 @@ RUN set -x && \
 	%%UPDATE_LIBPATH%% && \
 	mkdir -p /var/lib/antpickax && \
 	chmod 0777 /var/lib/antpickax && \
+	mkdir -p /var/run/antpickax && \
+	chmod 0777 /var/run/antpickax && \
+	mkdir -p /etc/antpickax && \
+	chmod 0777 /etc/antpickax && \
 	%%PKG_UNINSTALL_BASE%% && \
 	%%POST_PROCESS%%
 

--- a/buildutils/libfullock.postinst
+++ b/buildutils/libfullock.postinst
@@ -25,10 +25,14 @@
 #
 
 #
-# Create /var/lib/antpickax directory
+# Create /var/run/antpickax, /var/lib/antpickax, /etc/antpickax directory
 #
 mkdir -p /var/lib/antpickax
 chmod 0777 /var/lib/antpickax
+mkdir -p /var/run/antpickax
+chmod 0777 /var/run/antpickax
+mkdir -p /etc/antpickax
+chmod 0777 /etc/antpickax
 
 #
 # Local variables:

--- a/buildutils/libfullock.spec.in
+++ b/buildutils/libfullock.spec.in
@@ -69,6 +69,8 @@ BuildRequires: git-core gcc-c++ make libtool
 %make_install
 find %{buildroot} -name '*.la' -exec rm -f {} ';'
 mkdir -p %{buildroot}/var/lib/antpickax
+mkdir -p %{buildroot}/var/run/antpickax
+mkdir -p %{buildroot}/etc/antpickax
 
 %if %{make_check}
 %check
@@ -98,6 +100,8 @@ rm -rf %{buildroot}
 %{_libdir}/libfullock.so.1*
 %{_mandir}/man3/*
 %dir %attr(0777,root,root) /var/lib/antpickax
+%dir %attr(0777,root,root) /var/run/antpickax
+%dir %attr(0777,root,root) /etc/antpickax
 
 #
 # devel package


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
`/var/run/antpickax` and `/etc/antpickax` have been added to the directories created by the package.