### PR TITLE
Avoided latest cppcheck error which maybe a false positive

### DIFF
--- a/lib/flcklistfilelock.h
+++ b/lib/flcklistfilelock.h
@@ -84,6 +84,9 @@ class FlListFileLock : public fllistbasefilelock
 // result	0	: same
 //			-1	: psrc2 is smaller than psrc1
 //			1	: psrc2 is larger than psrc1
+
+// cppcheck-suppress unmatchedSuppression
+// cppcheck-suppress constParameterPointer
 inline int fl_compare_list_base(const PFLFILELOCK psrc1, const PFLFILELOCK psrc2)
 {
 	int result = 0;

--- a/lib/flcklistlocker.h
+++ b/lib/flcklistlocker.h
@@ -78,6 +78,9 @@ class FlListLocker : public fllistbaselocker
 // result	0	: same
 //			-1	: psrc2 is smaller than psrc1
 //			1	: psrc2 is larger than psrc1
+
+// cppcheck-suppress unmatchedSuppression
+// cppcheck-suppress constParameterPointer
 inline int fl_compare_list_base(const PFLLOCKER psrc1, const PFLLOCKER psrc2)
 {
 	if(psrc1->flckpid < psrc2->flckpid){

--- a/lib/flcklistncond.h
+++ b/lib/flcklistncond.h
@@ -98,6 +98,9 @@ class FlListNCond : public fllistbasencond
 // result	0	: same
 //			-1	: psrc2 is smaller than psrc1
 //			1	: psrc2 is larger than psrc1
+
+// cppcheck-suppress unmatchedSuppression
+// cppcheck-suppress constParameterPointer
 inline int fl_compare_list_base(const PFLNAMEDCOND psrc1, const PFLNAMEDCOND psrc2)
 {
 	if(psrc1->hash < psrc2->hash){

--- a/lib/flcklistnmtx.h
+++ b/lib/flcklistnmtx.h
@@ -99,6 +99,9 @@ class FlListNMtx : public fllistbasenmtx
 // result	0	: same
 //			-1	: psrc2 is smaller than psrc1
 //			1	: psrc2 is larger than psrc1
+
+// cppcheck-suppress unmatchedSuppression
+// cppcheck-suppress constParameterPointer
 inline int fl_compare_list_base(const PFLNAMEDMUTEX psrc1, const PFLNAMEDMUTEX psrc2)
 {
 	if(psrc1->hash < psrc2->hash){

--- a/lib/flcklistofflock.h
+++ b/lib/flcklistofflock.h
@@ -101,6 +101,9 @@ class FlListOffLock : public fllistbaseofflock
 // result	0	: same
 //			-1	: psrc2 is smaller than psrc1
 //			1	: psrc2 is larger than psrc1
+
+// cppcheck-suppress unmatchedSuppression
+// cppcheck-suppress constParameterPointer
 inline int fl_compare_list_base(const PFLOFFLOCK psrc1, const PFLOFFLOCK psrc2)
 {
 	int	result = 0;

--- a/lib/flcklistwaiter.h
+++ b/lib/flcklistwaiter.h
@@ -85,6 +85,9 @@ class FlListWaiter : public fllistbasewaiter
 //
 // [NOTE] check only lockstatus
 //
+
+// cppcheck-suppress unmatchedSuppression
+// cppcheck-suppress constParameterPointer
 inline int fl_compare_list_base(const PFLWAITER psrc1, const PFLWAITER psrc2)
 {
 	if(psrc1->lockstatus < psrc2->lockstatus){

--- a/tests/fcntl_mptest.cc
+++ b/tests/fcntl_mptest.cc
@@ -540,6 +540,8 @@ static bool MtReadWriteLock(PPROCPARAM pProcparam, PCHPARAM pParams)
 	return true;
 }
 
+// cppcheck-suppress unmatchedSuppression
+// cppcheck-suppress constParameterPointer
 static bool MtMutexLock(const PPROCPARAM pProcparam, const PCHPARAM pParams)
 {
 	ERR("Do not support Mutex Lock for fcntl.");


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
The latest cppcheck(v2.11 or 2.14 or later) is falsely detecting a `constParameterPointer` error when specifying `const` using the typedef name of a structure pointer.
Therefore, avoided this by adding an inline suppress.